### PR TITLE
Update link to techwear collection

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -94,7 +94,7 @@ export default function Home() {
                   </p>
 
                   <a
-                    href="techwear"
+                    href="/store/type/techwear"
                     className="mt-8 inline-block rounded border border-indigo-600 bg-indigo-600 px-12 py-3 text-sm font-medium text-white hover:bg-transparent hover:text-indigo-600 focus:outline-none focus:ring active:text-indigo-500"
                   >
                     ir a la colección


### PR DESCRIPTION
The link to the techwear collection on the main page was pointing to a non-existent page. This PR updates the link to point to the correct location.